### PR TITLE
timepoint rework

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,9 @@
 import argparse
 import logging
-from typing import Union
+from typing import Union, Sequence
 
 import cv2
+import itertools
 import numpy as np
 from clams import ClamsApp, Restifier
 from mmif import Mmif, DocumentTypes, View, AnnotationTypes, Document
@@ -37,6 +38,10 @@ class EastTextDetection(ClamsApp):
             self.logger.debug(f"Running on all images")
             mmif = self.run_on_images(mmif, new_view)
         return mmif
+
+                
+    def concat_boxes(box_group):
+        pass 
 
     def run_on_images(self, mmif: Mmif, new_view: View) -> Mmif:
         for imgdocument in mmif.get_documents_by_type(DocumentTypes.ImageDocument):
@@ -80,11 +85,23 @@ class EastTextDetection(ClamsApp):
                 bb_annotation = new_view.new_annotation(AnnotationTypes.BoundingBox)
                 tp = vdh.convert(time=fn, in_unit='frame', out_unit=config['timeUnit'], fps=videodocument.get_property("fps"))
                 self.logger.debug(f"Adding a timepoint at frame: {fn} >> {tp}")
-                bb_annotation.add_property("timePoint", tp)
+
+                tp_annotation = new_view.new_annotation(AnnotationTypes.TimePoint)
+                tp_annotation.add_property("timeUnit", config["timeUnit"])
+                tp_annotation.add_property("timePoint", tp)
+
+                #bb_annotation.add_property("timePoint", tp)
                 bb_annotation.add_property("boxType", "text")
                 x0, y0, x1, y1 = box
                 bb_annotation.add_property("coordinates", [[x0, y0], [x1, y0], [x0, y1], [x1, y1]])
+
+                alignment_annotation = new_view.new_annotation(AnnotationTypes.Alignment)
+                alignment_annotation.add_property("source", tp_annotation.id)
+                alignment_annotation.add_property("target", bb_annotation.id)
+
         return mmif
+
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/app.py
+++ b/app.py
@@ -39,10 +39,6 @@ class EastTextDetection(ClamsApp):
             mmif = self.run_on_images(mmif, new_view)
         return mmif
 
-                
-    def concat_boxes(box_group):
-        pass 
-
     def run_on_images(self, mmif: Mmif, new_view: View) -> Mmif:
         for imgdocument in mmif.get_documents_by_type(DocumentTypes.ImageDocument):
             image = cv2.imread(imgdocument.location)

--- a/metadata.py
+++ b/metadata.py
@@ -47,10 +47,15 @@ def appmetadata() -> AppMetadata:
     metadata.add_parameter(
         name="stopAt",
         type="integer",
-        default="2 * 60 * 60 * 30",  # ~2 hours of video at 30fps
+        default=108000,  # ~2 hours of video at 30fps 1 * 60 * 60 * 30
         description="Frame number to stop running. Only works with VideoDocument input. The default is roughly 2 hours of video at 30fps.",
     )
-    
+    metadata.add_parameter(
+        name="mergeBoxes",
+        type="boolean",
+        default=False,
+        description="if True, creates a single merged bounding box from all detected boxes."
+    )
     return metadata
 
 


### PR DESCRIPTION
This PR rewrites the timepoint annotation for the East app. 
Currently, TimePoints are saved as a property of the bounding box. This approach is flawed, as outlined in #1 . This PR adds separate Alignment and TimePoint annotations to the view for each bounding box.
